### PR TITLE
upversion

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,5 @@
 minecraft.version=1.7.10
 forge.version=10.13.4.1614
-amdiforge.version=1.7.10-1.0.1
+amdiforge.version=1.7.10-1.0.2
 
 yamcore.version=0.5.78


### PR DESCRIPTION
An old version of AMDIForge shipped in 2.1.2.2 test zip for server, because it had same filename. 

Up the version.